### PR TITLE
Fix duplicate Item object references in Lunacid alchemy pre_fill

### DIFF
--- a/worlds/lunacid/__init__.py
+++ b/worlds/lunacid/__init__.py
@@ -223,10 +223,10 @@ class LunacidWorld(World):
 
         if self.options.etnas_pupil and self.options.dropsanity == self.options.dropsanity.option_randomized:
             alchemy_items = []
-            for alchemy_item in Alchemy.necessary_alchemy_items:
-                alchemy_items.append(Item(alchemy_item, ItemClassification.progression | ItemClassification.useful,
-                                          self.item_name_to_id[alchemy_item], self.player))
-            alchemy_items *= 5  # make sure there's enough of them to go around
+            for _ in range(5):  # make sure there's enough of them to go around
+                for alchemy_item in Alchemy.necessary_alchemy_items:
+                    alchemy_items.append(Item(alchemy_item, ItemClassification.progression | ItemClassification.useful,
+                                              self.item_name_to_id[alchemy_item], self.player))
             self.local_alchemy = alchemy_items
 
         if self.multiworld.players == 1:


### PR DESCRIPTION
Each item instance can only be placed at one location, but the original code was placing the same item instances into local_alchemy items multiple times by multiplying the list. It caused these items to be placed in multiple locations during pre_fill. Create distinct item instances instead.

Using this [fuzzer hook] to detect that kind of inconsistencies, failures went from ~7% to 0.

[fuzzer hook]: https://github.com/Mysteryem/Archipelago-fuzzer/blob/7bc2dcd4367d1450cda11f0c1bc1f2edb385e218/hooks/check_placement_item_location_references.py

Diff is better looked at with whitespace changes off.