### PR TITLE
Fix the universal tracker integration

### DIFF
--- a/worlds/lunacid/Tracker.py
+++ b/worlds/lunacid/Tracker.py
@@ -29,6 +29,8 @@ def setup_options_from_slot_data(world: "LunacidWorld"):
             world.options.secret_door_lock.value = world.passthrough["secret_door_lock"]
             world.options.switch_locks.value = world.passthrough["switch_locks"]
             world.options.door_locks.value = world.passthrough["door_locks"]
+            world.options.challenges.value = world.passthrough["challenges"]
+            world.options.tricks_and_glitches.value = world.passthrough["tricks_and_glitches"]
             world.starting_weapon = world.passthrough["starting_weapon"]
             world.weapon_elements = world.passthrough["elements"]
             stats = world.passthrough["created_class_stats"]

--- a/worlds/lunacid/__init__.py
+++ b/worlds/lunacid/__init__.py
@@ -150,6 +150,7 @@ class LunacidWorld(World):
         self.custom_class_stats = {}
 
     def generate_early(self) -> None:
+        Tracker.setup_options_from_slot_data(self)
         self.package_custom_class()
         self.level = self.determine_starting_level()
         self.enemy_random_data, enemy_regions = self.randomize_enemies()
@@ -160,7 +161,6 @@ class LunacidWorld(World):
             self.enemy_regions = enemy_regions
         if self.options.challenges == self.options.challenges.option_exp:
             self.options.levelsanity.value = self.options.levelsanity.option_false
-        Tracker.setup_options_from_slot_data(self)
 
     def create_item(self, name: str, override_classification: ItemClassification = None) -> "LunacidItem":
         if name == self.glitches_item_name:

--- a/worlds/lunacid/__init__.py
+++ b/worlds/lunacid/__init__.py
@@ -553,7 +553,8 @@ class LunacidWorld(World):
                                    "quenchsanity", "etnas_pupil", "switch_locks", "door_locks", "random_elements",
                                    "secret_door_lock", "death_link", "starting_class",
                                    "starting_area", "levelsanity", "bookworm",
-                                   "grasssanity", "breakables", "total_strange_coin", "random_equip_stats", "silver_link"),
+                                   "grasssanity", "breakables", "total_strange_coin", "random_equip_stats", "silver_link",
+                                   "challenges", "tricks_and_glitches"),
             "entrances": self.randomized_entrances
         }
 


### PR DESCRIPTION
Add missing options in slot data and interpret them earlier in `generate_early`.

Using the UT [fuzzer hook](https://github.com/FarisTheAncient/Archipelago/blob/06cf9f47d6d94cde82158736a9e65b93d410fba0/worlds/tracker/fuzzer_hook.py), this goes from 83% failures to 0%.