### PR TITLE
Fix mutating starting_weapon global in determine_starting_weapon

### DIFF
--- a/worlds/lunacid/Items.py
+++ b/worlds/lunacid/Items.py
@@ -181,7 +181,7 @@ def create_spells(item_factory: LunacidItemFactory, equipment_by_elements: Dict[
 
 
 def determine_starting_weapon(random: Random, options: LunacidOptions) -> str:
-    starting_selection = starting_weapon
+    starting_selection = starting_weapon.copy()
     if options.shopsanity:
         starting_selection += shop_starting_weapons
     if options.dropsanity:


### PR DESCRIPTION
## What is this fixing or adding?

Each call to determine_starting_weapon would mutate the `data.item_data.starting_weapon` list if shopsanity, dropsanity or quenchsanity were enabled for the slot in question. These mutations to the list would carry over to other slots in the multiworld when they wanted to determine their own starting weapon, potentially picking a starting weapon that was not valid for their slot.

In a WebHost generation context, this would also have been a memory leak because the `starting_weapon` list would grow in size with each generation containing a Lunacid slot with shopsanity, dropsanity or quenchsanity enabled.

## How was this tested?

I have a WIP fuzzer hook to try to detect cases where module-level globals are being accidentally modified and it picked up `starting_weapon` getting modified. With this fix in place, Lunacid no longer fails the WIP fuzzer hook.

I also generated with `--seed 1` with 3 Lunacid yamls each with shopsanity, dropsanity (uniques) and quenchsanity enabled. Before this PR, this produced one specific deterministic output. After this PR, this produces a different specific deterministic output, so the change in this PR does have an effect on generation with multiple Lunacid slots.